### PR TITLE
LLT-4065 Fix allowed IPv6 addresses reporting

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -971,7 +971,7 @@ impl Adapter {
                         IpNet::V4(Ipv4Net::new(address, prefix_length).expect("prefix is valid"))
                     }
                     winapi::shared::ws2def::AF_INET6 => {
-                        let octets = unsafe { allowed_ip.Address.V6.u.Byte };
+                        let octets: [u16; 8] = unsafe { allowed_ip.Address.V6.u.Word };
                         let address = Ipv6Addr::from(octets);
                         IpNet::V6(Ipv6Net::new(address, prefix_length).expect("prefix is valid"))
                     }


### PR DESCRIPTION
IPv6 address in WIndows are represented in `[u8; 16]` or `[u16; 8]` form. The `[u8; 16]`, which were used earlier, has incorrect endianness set, so switching to `[u16; 8]`.