### PR TITLE
Fix ipv6 allowed_ips addresses in get_config_uapi

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -219,11 +219,11 @@ impl Adapter {
     }
 
     /// Sets the wireguard configuration of this adapter using xplatform structures
-    /// 
-    /// 
+    ///
+    ///
     /// This is reimplementation of wg-nt-wrapper set_config() function with
     /// return type that is compatible with telio::Adapter type.
-    /// 
+    ///
     /// # Panics
     /// 1. If writing to WIREGUARD_INTERFACE allocation would overflow the buffer.
     /// 2. If the writer's internal pointer does not meet the alignment requirements of WIREGUARD_INTERFACE.
@@ -510,7 +510,7 @@ impl Adapter {
             0 => Err("WireGuardSetConfiguration failed".into()),
             _ => Ok(()),
         }
-    }    
+    }
 
     /// Assigns this adapter an ip address and adds route(s) so that packets sent
     /// within the `interface_addr` ipnet will be sent across the WireGuard VPN
@@ -688,13 +688,13 @@ impl Adapter {
     }
 
     /// Gets the current configuration of this adapter as wireguard_uapi::get::Peer struct
-    /// 
+    ///
     /// This is reimplementation of wg-nt-wrapper get_config() function with
     /// return type that is compatible with telio::Adapter type.
-    /// 
+    ///
     /// It also fixes wrapper issues with timestamp underflow, and sets all
     /// required fields, e.g. flags, appropriately
-    /// 
+    ///
     /// # Panics
     /// 1. If reading WIREGUARD_INTERFACE, WIREGUARD_PEER or WIREGUARD_ALLOWED_IP would overflow the buffer.
     /// 2. If the internal pointer does not meet the alignment requirements of the above structures.
@@ -782,7 +782,7 @@ impl Adapter {
                 _ => {
                     panic!("Illegal address family {}", address_family);
                 }
-            }; 
+            };
 
             // TODO: Replace hardcoded value with the ones in the bitfields or wireguard_nt_raw
             let mut wg_peer = wireguard_uapi::get::Peer {
@@ -800,6 +800,7 @@ impl Adapter {
                 // # Safety:
                 // 1. `WireGuardGetConfiguration` writes zero or more `WIREGUARD_ALLOWED_IP`s immediately after the WIREGUARD_PEER we read above.
                 // 2. We rely on Wireguard-NT to specify the number of allowed ips written, and therefore we never read too many times unless Wireguard-NT (wrongly) tells us to
+
                 let allowed_ip_raw: WIREGUARD_ALLOWED_IP = unsafe { reader.read() };
                 let prefix_length = allowed_ip_raw.Cidr;
                 let allowed_ip = match allowed_ip_raw.AddressFamily as i32 {
@@ -819,11 +820,8 @@ impl Adapter {
                         }
                     }
                     winapi::shared::ws2def::AF_INET6 => {
-                        let octets = unsafe { allowed_ip_raw.Address.V6.u.Word };
-                        let address = IpAddr::V6(Ipv6Addr::new(
-                            octets[0], octets[1], octets[2], octets[3], octets[4], octets[5],
-                            octets[6], octets[7],
-                        ));
+                        let octets = unsafe { allowed_ip_raw.Address.V6.u.Byte };
+                        let address = IpAddr::V6(Ipv6Addr::from(octets));
                         wireguard_uapi::get::AllowedIp {
                             family: 6,
                             ipaddr: address,
@@ -900,7 +898,7 @@ impl Adapter {
         let now_instant = Instant::now();
         let unix_duration = now
             .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("Time set before unix epoch");        
+            .expect("Time set before unix epoch");
         // The number of 100ns intervals between 1-1-1600 and 1-1-1970
         const UNIX_EPOCH_FROM_1_1_1600: u64 = 116444736000000000;
         // Calculate now based on the number of 100ns intervals since 1-1-1600

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -314,7 +314,7 @@ impl Adapter {
                             wg_peer.Endpoint.Ipv4.sin_addr = addr;
                         }
                         SocketAddr::V6(v6) => {
-                            let addr = unsafe { std::mem::transmute(v6.ip().segments()) };
+                            let addr = unsafe { std::mem::transmute(v6.ip().octets()) };
                             wg_peer.Endpoint.Ipv6.sin6_family =
                                 winapi::shared::ws2def::AF_INET6 as u16;
                             wg_peer.Endpoint.Ipv6.sin6_port =
@@ -360,7 +360,7 @@ impl Adapter {
                             wg_allowed_ip.Cidr = v4.prefix_len();
                         }
                         IpNet::V6(v6) => {
-                            let addr = unsafe { std::mem::transmute(v6.addr().segments()) };
+                            let addr = unsafe { std::mem::transmute(v6.addr().octets()) };
                             wg_allowed_ip.Address.V6 = addr;
                             wg_allowed_ip.AddressFamily = winapi::shared::ws2def::AF_INET6 as u16;
                             wg_allowed_ip.Cidr = v6.prefix_len();
@@ -465,7 +465,7 @@ impl Adapter {
                     wg_peer.Endpoint.Ipv4.sin_addr = addr;
                 }
                 SocketAddr::V6(v6) => {
-                    let addr = unsafe { std::mem::transmute(v6.ip().segments()) };
+                    let addr = unsafe { std::mem::transmute(v6.ip().octets()) };
                     wg_peer.Endpoint.Ipv6.sin6_family = winapi::shared::ws2def::AF_INET6 as u16;
                     wg_peer.Endpoint.Ipv4.sin_port = u16::from_ne_bytes(v6.port().to_be_bytes());
                     wg_peer.Endpoint.Ipv6.sin6_addr = addr;
@@ -486,7 +486,7 @@ impl Adapter {
                         wg_allowed_ip.Cidr = v4.prefix_len();
                     }
                     IpNet::V6(v6) => {
-                        let addr = unsafe { std::mem::transmute(v6.addr().segments()) };
+                        let addr = unsafe { std::mem::transmute(v6.addr().octets()) };
                         wg_allowed_ip.Address.V6 = addr;
                         wg_allowed_ip.AddressFamily = winapi::shared::ws2def::AF_INET6 as u16;
                         wg_allowed_ip.Cidr = v6.prefix_len();
@@ -551,7 +551,7 @@ impl Adapter {
                     IpNet::V6(v6) => {
                         *default_route.DestinationPrefix.Prefix.si_family_mut() = AF_INET6 as u16;
                         default_route.DestinationPrefix.Prefix.Ipv6_mut().sin6_addr =
-                            std::mem::transmute(v6.addr().segments());
+                            std::mem::transmute(v6.addr().octets());
 
                         default_route.DestinationPrefix.PrefixLength = v6.prefix_len();
 
@@ -582,7 +582,7 @@ impl Adapter {
                     IpNet::V6(interface_addr_v6) => {
                         address_row.Address.Ipv6_mut().sin6_family = AF_INET6 as u16;
                         address_row.Address.Ipv6_mut().sin6_addr =
-                            std::mem::transmute(interface_addr_v6.addr().segments());
+                            std::mem::transmute(interface_addr_v6.addr().octets());
                     }
                 }
 
@@ -772,8 +772,8 @@ impl Adapter {
                     SocketAddr::V4(SocketAddrV4::new(address, port))
                 }
                 winapi::shared::ws2def::AF_INET6 => {
-                    let segments: [u16; 8] = unsafe { endpoint.Ipv6.sin6_addr.u.Word };
-                    let address = Ipv6Addr::from(segments);
+                    let octets = unsafe { endpoint.Ipv6.sin6_addr.u.Byte };
+                    let address = Ipv6Addr::from(octets);
                     let port = u16::from_be(unsafe { endpoint.Ipv6.sin6_port });
                     let flow_info = unsafe { endpoint.Ipv6.sin6_flowinfo };
                     let scope_id = unsafe { endpoint.Ipv6.__bindgen_anon_1.sin6_scope_id };
@@ -819,10 +819,10 @@ impl Adapter {
                         }
                     }
                     winapi::shared::ws2def::AF_INET6 => {
-                        let segments: [u16; 8] = unsafe { allowed_ip_raw.Address.V6.u.Word };
+                        let octets = unsafe { allowed_ip_raw.Address.V6.u.Word };
                         let address = IpAddr::V6(Ipv6Addr::new(
-                            segments[0], segments[1], segments[2], segments[3], segments[4], segments[5],
-                            segments[6], segments[7],
+                            octets[0], octets[1], octets[2], octets[3], octets[4], octets[5],
+                            octets[6], octets[7],
                         ));
                         wireguard_uapi::get::AllowedIp {
                             family: 6,
@@ -924,8 +924,8 @@ impl Adapter {
                     SocketAddr::V4(SocketAddrV4::new(address, port))
                 }
                 winapi::shared::ws2def::AF_INET6 => {
-                    let segments: [u16; 8] = unsafe { endpoint.Ipv6.sin6_addr.u.Word };
-                    let address = Ipv6Addr::from(segments);
+                    let octets = unsafe { endpoint.Ipv6.sin6_addr.u.Byte };
+                    let address = Ipv6Addr::from(octets);
                     let port = u16::from_be(unsafe { endpoint.Ipv6.sin6_port });
                     let flow_info = unsafe { endpoint.Ipv6.sin6_flowinfo };
                     let scope_id = unsafe { endpoint.Ipv6.__bindgen_anon_1.sin6_scope_id };
@@ -971,8 +971,8 @@ impl Adapter {
                         IpNet::V4(Ipv4Net::new(address, prefix_length).expect("prefix is valid"))
                     }
                     winapi::shared::ws2def::AF_INET6 => {
-                        let segments: [u16; 8] = unsafe { allowed_ip.Address.V6.u.Word };
-                        let address = Ipv6Addr::from(segments);
+                        let octets: [u16; 8] = unsafe { allowed_ip.Address.V6.u.Word };
+                        let address = Ipv6Addr::from(octets);
                         IpNet::V6(Ipv6Net::new(address, prefix_length).expect("prefix is valid"))
                     }
                     _ => {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -971,7 +971,7 @@ impl Adapter {
                         IpNet::V4(Ipv4Net::new(address, prefix_length).expect("prefix is valid"))
                     }
                     winapi::shared::ws2def::AF_INET6 => {
-                        let octets: [u16; 8] = unsafe { allowed_ip.Address.V6.u.Word };
+                        let octets = unsafe { allowed_ip.Address.V6.u.Byte };
                         let address = Ipv6Addr::from(octets);
                         IpNet::V6(Ipv6Net::new(address, prefix_length).expect("prefix is valid"))
                     }


### PR DESCRIPTION
The address was not translated correctly from byte array into
Rust's Ipv6Addr. An IPv6 address when read from a continous byte array
as u16 words will contain numbers in big endian. In order to make
previous solution work one would need to call u16::from_be function to
convert them into target's endianness before pasing them into the
Ipv6Addr constructor. It's probably easier to just pass 16 elements long u8
array instead to avoid confusion.

For this fix I've also reverted two previous commits that have tried to
address this issue but unfortunately introduced another bug that was
just a cover up for the first one. We were doing incorrect translations
while setting and getting so in logs everything looked as expected, but
the value in wg interface itself was wrong.
