### PR TITLE
[LLT-5479] Improve logs quality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows
 
 [dependencies]
 widestring = "0.4"
-log = "0.4"
 rand = "0.8"
 bitflags = "1.3"
+tracing = "0.1.40"
 
 libloading = "0.7"
 ipnet = "2.3"

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use crate::wireguard_nt_raw;
-use log::*;
+use tracing::{error, info, warn};
 use widestring::U16CStr;
 
 use std::sync::atomic::{AtomicBool, Ordering};


### PR DESCRIPTION
This commit includes two changes:
 - adds last OS error to a few returned errors
 - replace `log` crate with `tracing` so Telio subscriber can just consume the logs it uses